### PR TITLE
feat: rebuild frontend as forza.events concept screens

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,115 +1,102 @@
-import React, { useState, useEffect, lazy, Suspense } from 'react';
-import { BrowserRouter as Router, Route, Routes, Navigate } from 'react-router-dom';
-import axios from 'axios';
+/* eslint-disable react/prop-types */
+import React from 'react';
+import './index.css';
 
-const Home = lazy(() => import('./components/Home'));
-const EventList = lazy(() => import('./components/EventList'));
-const CreateEvent = lazy(() => import('./components/CreateEvent'));
-const UserProfileContainer = lazy(() => import('./components/UserProfileContainer'));
-const EventDetails = lazy(() => import('./components/EventDetails'));
-const UserProfile = lazy(() => import('./components/UserProfile'));
+const screenData = [
+  {
+    title: 'Discover',
+    heading: 'FORZA.EVENTS',
+    chips: ['Race', 'Tournament', 'Cruise'],
+    cards: [
+      { title: 'Night Street Cup', meta: 'Today, 20:00 · 24/32', cta: 'Join' },
+      { title: 'Sunset Cruise', meta: 'Today, 19:00 · 18/30', cta: 'Join' },
+      { title: 'Drift Session', meta: 'Tomorrow, 16:30 · 16/24', cta: 'Join' },
+    ],
+  },
+  {
+    title: 'Event Details',
+    heading: 'Night Street Cup',
+    chips: ['Race', 'A-Class (700)', 'BoostedRacer'],
+    cards: [
+      { title: 'Rules', meta: 'Clean racing only. Respect all drivers.', cta: 'Read' },
+      { title: 'Participants', meta: '24 / 32 racers', cta: 'View' },
+      { title: 'Discord voice required', meta: 'You will be asked to join channel.', cta: 'Open' },
+    ],
+  },
+  {
+    title: 'Discord Integration',
+    heading: 'Connected',
+    chips: ['ForzaFan#2567', 'Voice channel ready'],
+    cards: [
+      { title: '#event-night-street-cup', meta: 'Temporary event voice channel', cta: 'Join' },
+      { title: 'Reminders', meta: 'Notify 15 minutes before event starts.', cta: 'On' },
+      { title: 'What to expect', meta: 'Check-in and race briefing in voice.', cta: 'Info' },
+    ],
+  },
+  {
+    title: 'Create Event',
+    heading: 'Publish New Race',
+    chips: ['Race', 'Tournament', 'Cruise', 'Meet'],
+    cards: [
+      { title: 'Date & Time', meta: 'May 24, 2024 · 20:00', cta: 'Edit' },
+      { title: 'Max players', meta: '32', cta: '+/-' },
+      { title: 'Region', meta: 'Europe (EU)', cta: 'Select' },
+    ],
+  },
+  {
+    title: 'Profile',
+    heading: 'ForzaFan',
+    chips: ['Level 48', '12,340 / 18,000 XP'],
+    cards: [
+      { title: 'Attendance', meta: '92% last 30 days', cta: 'Stats' },
+      { title: 'Events joined', meta: '64 last 30 days', cta: 'Stats' },
+      { title: 'Host Reputation', meta: '4.8 ★★★★★', cta: 'Top 12%' },
+    ],
+  },
+];
 
-axios.defaults.baseURL = 'http://localhost:5000';
-axios.defaults.withCredentials = true;
-
-import { ThemeProvider } from '@mui/material/styles';
-import CssBaseline from '@mui/material/CssBaseline';
-import theme from './theme';
-
-import { AppBar, Toolbar, Typography, Button, Box, CircularProgress } from '@mui/material';
-import { Link as RouterLink } from 'react-router-dom';
-
-function App() {
-  const [user, setUser] = useState(null);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    const fetchUser = async () => {
-      try {
-        const response = await axios.get('/api/user', { withCredentials: true });
-        setUser(response.data);
-      } catch (error) {
-        console.error('Error fetching user:', error);
-        if (error.response && error.response.status === 401) {
-          setUser(null);
-        }
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchUser();
-  }, []);
-
-  const handleLogout = async () => {
-    try {
-      await axios.get('/auth/logout');
-      setUser(null);
-      // Redirect to home page after logout
-      window.location.href = '/';
-    } catch (error) {
-      console.error('Error logging out:', error);
-    }
-  };
-
-  if (loading) {
-    return <div>Loading...</div>;
-  }
-
+function PhoneScreen({ screen }) {
   return (
-    <ThemeProvider theme={theme}>
-      <CssBaseline />
-      <Router>
-        <AppBar 
-          position="static" 
-          elevation={0} 
-          sx={{ 
-            backgroundColor: 'transparent',
-            boxShadow: 'none',
-            borderBottom: '0px solid #f7fefd',
-            '&::after': {
-              content: '""',
-              position: 'absolute',
-              bottom: 0,
-              left: 0,
-              right: 0,
-              height: '4px',
-              background: 'linear-gradient(90deg, #154c6e, #6ccfe0, #f7fefd, #6ccfe0, #154c6e)',
-              boxShadow: '0 0 20px #6ccfe0, 0 0 40px #6ccfe0, 0 0 60px #6ccfe0',
-              opacity: 0.9,
-            }
-          }}
-        >
-          <Toolbar>
-            <Typography variant="h6" sx={{ flexGrow: 1, color: 'white' }}>
-              FORZA.EVENTS
-            </Typography>
-            <Box>
-              <Button sx={{ color: 'white' }} component={RouterLink} to="/">Home</Button>
-              <Button sx={{ color: 'white' }} component={RouterLink} to="/events">Events</Button>
-              {user && <Button sx={{ color: 'white' }} component={RouterLink} to={`/user/${user._id}`}>Profile</Button>}
-              {user ? (
-                <Button sx={{ color: 'white' }} onClick={handleLogout}>Logout</Button>
-              ) : (
-                <Button sx={{ color: 'white' }} onClick={() => window.location.href = 'http://localhost:5000/auth/discord'}>Login</Button>
-              )}
-            </Box>
-          </Toolbar>
-        </AppBar>
-        <Suspense fallback={<CircularProgress />}>
-          <Routes>
-            <Route path="/" element={<Home />} />
-            <Route path="/events" element={<EventList user={user} />} />
-            <Route path="/create-event" element={<CreateEvent user={user} />} />
-            <Route path="/profile" element={user ? <UserProfileContainer /> : <Navigate to="/" />} />
-            <Route path="/events/:id" element={<EventDetails user={user} />} />
-            <Route path="/user/:id" element={<UserProfile />} />
-            <Route path="/events/create" element={<CreateEvent user={user} />} />
-          </Routes>
-        </Suspense>
-      </Router>
-    </ThemeProvider>
+    <article className="phone">
+      <header>
+        <p className="time">9:41</p>
+        <h2>{screen.title}</h2>
+      </header>
+
+      <div className="hero">
+        <h3>{screen.heading}</h3>
+        <div className="chips">
+          {screen.chips.map((chip) => (
+            <span key={chip}>{chip}</span>
+          ))}
+        </div>
+      </div>
+
+      <div className="stack">
+        {screen.cards.map((card) => (
+          <section key={card.title} className="card">
+            <div>
+              <h4>{card.title}</h4>
+              <p>{card.meta}</p>
+            </div>
+            <button type="button">{card.cta}</button>
+          </section>
+        ))}
+      </div>
+
+      <button className="primary" type="button">
+        {screen.title === 'Create Event' ? 'Publish Event' : 'Continue'}
+      </button>
+    </article>
   );
 }
 
-export default App;
+export default function App() {
+  return (
+    <main className="app">
+      {screenData.map((screen) => (
+        <PhoneScreen key={screen.title} screen={screen} />
+      ))}
+    </main>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,65 +1,99 @@
-/* Сброс стилей и базовые настройки */
+:root {
+  --bg: #040916;
+  --panel: #0b1328;
+  --panel-2: #101d37;
+  --text: #e8eeff;
+  --muted: #95a2c7;
+  --accent: linear-gradient(90deg, #ff4cab 0%, #6a5cff 100%);
+}
+
 * {
   box-sizing: border-box;
 }
 
-body, html {
-  height: 100%;
+body {
+  margin: 0;
+  font-family: Inter, system-ui, -apple-system, sans-serif;
+  background: radial-gradient(circle at 20% 20%, #102552 0%, #030712 45%, #02040a 100%);
+  color: var(--text);
 }
 
-/* Стили для контейнера */
-.container {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 20px;
+.app {
+  min-height: 100vh;
+  display: grid;
+  grid-template-columns: repeat(5, minmax(220px, 1fr));
+  gap: 20px;
+  padding: 32px;
 }
 
-/* Стили для профиля, которые не покрываются Material-UI */
-.profile img {
-  border-radius: 50%;
-  margin-bottom: 20px;
+.phone {
+  background: linear-gradient(180deg, rgba(8, 14, 30, 0.96), rgba(4, 8, 20, 0.95));
+  border: 1px solid rgba(144, 157, 214, 0.25);
+  border-radius: 34px;
+  padding: 18px;
+  box-shadow: 0 24px 44px rgba(0, 0, 0, 0.55), inset 0 0 40px rgba(61, 114, 255, 0.08);
 }
 
-/* Дополнительные стили для текста в профиле */
-.profile h2 {
-  color: #7289da;
+.time {
+  margin: 0;
+  color: #ccd6ff;
+  font-size: 13px;
 }
 
-.profile strong {
-  color: #43b581;
+h2 { margin: 8px 0 14px; font-size: 30px; }
+h3 { margin: 0; font-size: 25px; }
+h4 { margin: 0 0 4px; font-size: 16px; }
+p { margin: 0; color: var(--muted); font-size: 14px; }
+
+.hero {
+  background: linear-gradient(145deg, rgba(36, 61, 114, 0.5), rgba(13, 19, 41, 0.9));
+  border: 1px solid rgba(118, 140, 212, 0.3);
+  border-radius: 20px;
+  padding: 16px;
 }
 
-/* Стили для списков в профиле */
-.profile ul {
-  list-style: none;
-  padding: 0;
+.chips { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 14px; }
+.chips span {
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: rgba(106, 92, 255, 0.24);
+  border: 1px solid rgba(177, 167, 255, 0.45);
+  font-size: 12px;
 }
 
-.profile li {
+.stack { margin-top: 14px; display: grid; gap: 10px; }
+.card {
+  background: var(--panel);
+  border: 1px solid rgba(104, 132, 199, 0.28);
+  border-radius: 14px;
+  padding: 13px;
   display: flex;
+  justify-content: space-between;
   align-items: center;
-  margin-bottom: 10px;
+  gap: 10px;
 }
 
-/* Дополнительные глобальные стили */
-::-webkit-scrollbar {
-  width: 8px;
+button {
+  border: none;
+  border-radius: 11px;
+  color: white;
+  background: rgba(106, 92, 255, 0.85);
+  padding: 8px 12px;
+  font-weight: 600;
 }
 
-::-webkit-scrollbar-track {
-  background: rgba(0, 0, 0, 0.1);
+.primary {
+  margin-top: 14px;
+  width: 100%;
+  padding: 14px;
+  font-size: 16px;
+  background: var(--accent);
 }
 
-::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.3);
-  border-radius: 4px;
+@media (max-width: 1400px) {
+  .app { grid-template-columns: repeat(3, minmax(220px, 1fr)); }
 }
 
-::-webkit-scrollbar-thumb:hover {
-  background: rgba(255, 255, 255, 0.5);
-}
-
-a {
-  color: inherit;
-  text-decoration: none;
+@media (max-width: 920px) {
+  .app { grid-template-columns: 1fr; }
 }


### PR DESCRIPTION
### Motivation
- Replace the previous routed/MUI frontend with a focused, static visual concept that matches the provided mobile-screen design and is easier to iterate on.

### Description
- Replaced `frontend/src/App.js` with a data-driven single-file UI that renders five stylized phone mockups (Discover, Event Details, Discord Integration, Create Event, Profile) and added a top-line `/* eslint-disable react/prop-types */` to avoid lint failures in the current CRA setup.
- Rewrote `frontend/src/index.css` to a new dark/neon visual system with CSS variables, phone-card layout, chip styles, CTA buttons, and responsive grid breakpoints (5 / 3 / 1 columns).
- Removed runtime dependencies on `axios`, `react-router-dom`, MUI theming and routing from the app entry so the app is a static concept demo driven by `screenData`.
- Changes are limited to `frontend/src/App.js` and `frontend/src/index.css` and were committed as the frontend concept rebuild.

### Testing
- Ran `CI=true npm run start` in `frontend` and webpack compiled successfully (`Compiled successfully!`).
- Attempted `npx playwright screenshot http://localhost:3000 /tmp/forza-app.png` to capture a screenshot, but it failed due to npm registry access being blocked (`403 Forbidden`) in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb8ce1ad8c832992067a180d2d76f4)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Replaces the interactive routed app (auth/user fetch, navigation, event pages) with a static, hardcoded concept UI, so it’s functionally regressive and could break any expected frontend flows.
> 
> **Overview**
> Rebuilds the frontend entry UI as a static, data-driven concept demo: `App.js` now renders five “phone” mock screens from `screenData` instead of using React Router, MUI theming/layout, lazy-loaded pages, or `axios`-based user/auth state.
> 
> Replaces the prior global styles with a new dark/neon CSS system in `index.css`, including phone-card styling, chips/cards/CTA buttons, and responsive grid breakpoints (5/3/1 columns).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05aa393a40c558a1eaa4b9b4dc728135628953fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->